### PR TITLE
:memo: Add PR template for pull request descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+# Motivation
+The background context and problem this pull request is addressing
+
+Example: The current FHIR Patient profile (Participant) does not include a critical field, birth sex, 
+that is contained in the input data. This means that assigned sex at birth data does not get captured in the FHIR server.
+
+# Approach
+The solution to the problem
+
+Example: Add an extension to the Participant profile to capture the Patient's assigned sex at birth.


### PR DESCRIPTION
# Motivation
Right now pull requests don't follow a specific format or require a description. This makes it hard to understand what the PR is about or the problem it addresses

# Approach
Add a pull request template to this github repo so that all PRs follow a standard