### PR TITLE
DRS preference in File profile

### DIFF
--- a/input/fsh/modules/files.fsh
+++ b/input/fsh/modules/files.fsh
@@ -142,14 +142,6 @@ Description: "Information about a file related to a research participant"
 * extension[file-format] ^short = "The file format used (EDAM is preferred)"
 * content.attachment.url 1..1 /*Location uri*/
 * content.attachment.url ^short = "The URI at which this data can be accessed"
-* content ^slicing.discriminator.type = #pattern
-* content ^slicing.discriminator.path = "code"
-* content ^slicing.rules = #openAtEnd
-* content ^slicing.ordered = false
-* content ^slicing.description = "Slicing pattern to make content.attachment require a DRS file type and allow other file types"
-* content contains
-  AdditionalFile 0..*
-* content[AdditionalFile].attachment only Attachment
 * extension contains LocationAccess named location-access 0..* /*Location Access Policy*/
 * extension[location-access] ^short = "If present, only those under the specific Access Policy can access the file in this location."
 * extension contains FileSize named file-size 1..1 /*File Size*/
@@ -173,12 +165,8 @@ Description: "Information about a DRS file related to a research participant"
 * content ^slicing.discriminator.type = #pattern
 * content ^slicing.discriminator.path = "code"
 * content ^slicing.rules = #openAtEnd
-* content ^slicing.ordered = false
+* content ^slicing.ordered = true
 * content ^slicing.description = "Slicing pattern to make content.attachment require a DRS file type and allow other file types"
 * content contains
-  DRS 1..1 and
-  Other 0..*
+  DRS 1..1 
 * content[DRS].attachment only DRSAttachment
-//* content[DRS].profile only 
-* content[Other].attachment only Attachment
-//* content[Other]. only uri

--- a/input/fsh/modules/files.fsh
+++ b/input/fsh/modules/files.fsh
@@ -111,6 +111,20 @@ Description: "Provides a list of hashes for confirming file transfers"
 * extension contains HashType named hash-type 1..1
 * extension[hash-type] ^short = "Algorithm used to calculate the hash (and size, where applicable)"
 
+Invariant: drs-uri-preferred
+Description: "attachment.url must start with ^drs://. A drs:// hostname-based URI, as defined in the DRS documentation, that tells clients how to access this object. The intent of this field is to make DRS objects self-contained, and therefore easier for clients to store and pass around.  For example, if you arrive at this DRS JSON by resolving a compact identifier-based DRS URI, the `self_uri` presents you with a hostname and properly encoded DRS ID for use in subsequent `access` endpoint calls."
+Expression: "$this.url.matches('^drs://.*')"
+Severity: #warning
+
+Profile: DRSAttachment
+Parent: Attachment
+Id: ncpi-drs-attachment
+Title: "DRS Attachment"
+Description: "A FHIR Attachment with a DRS url."
+* ^version = "0.1.0"
+* ^status = #draft
+* obeys drs-uri-preferred
+
 /** TODO Add Related file to metadata - AH 2024-07-30 */ 
 
 Profile: NcpiFile
@@ -126,8 +140,9 @@ Description: "Information about a file related to a research participant"
 * subject ^short = "The participant(s) for whom this file contains data (i.e., ParticipantID)"
 * extension contains FileFormat named file-format 1..1 /*File Format*/
 * extension[file-format] ^short = "The file format used (EDAM is preferred)"
-* content.attachment.url 1..1 /*Location uri*/
-* content.attachment.url ^short = "The URI at which this data can be accessed"
+* content.attachment only DRSAttachment
+* content.attachment 1..1 /*Location uri*/
+* content.attachment ^short = "The URI at which this data can be accessed"
 * extension contains LocationAccess named location-access 0..* /*Location Access Policy*/
 * extension[location-access] ^short = "If present, only those under the specific Access Policy can access the file in this location."
 * extension contains FileSize named file-size 1..1 /*File Size*/


### PR DESCRIPTION
# Motivation
Make DRS file types the preferred attachment type for the File profile and send out a warning if the attachment URI is not DRS.

# Approach
Adapt the [DRSattachment](https://github.com/NIH-NCPI/ncpi-fhir-ig/blob/main/input/fsh/Profile-DRSAttachment.fsh) profile to make DRS preferred but not strictly required.