### PR TITLE
Update README to remove invalid link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 Welcome to NCPI FHIR IG 2. The goal for this repository is to relaunch the IG project
 with a clearer focus, an explicit style guide using the current tools including Sushi v3. 
 
-This repository is currently under development.
-Feel free to [take a look](https://torstees.github.io/ncpi-fhir-ig-2/) at the working version.
-
 ## 👨🏻‍💻 Contributor's Guide 
 
 If you would like to contribute to this project, please take a look at the 


### PR DESCRIPTION
An outdated link was accidentally included in the README that has now been removed.

# Motivation
There is a broken link at the top of the README that needs to be removed. 

# Approach
The link has been removed. 
