### PR TITLE
Delete FSH-Generated Files from Repo

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -43,6 +43,9 @@ jobs:
         run: |
           chmod +x ./_genonce.sh
           ./_genonce.sh
+      - name: Capture FSH-Generated
+        run: |
+          cp -r fsh-generated output
 
       - name: 🚀 Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.2

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -45,7 +45,7 @@ jobs:
           ./_genonce.sh
       - name: Capture FSH-Generated
         run: |
-          cp -r fsh-generated output
+          ./_build_fgen_index.rb
 
       - name: 🚀 Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Capture FSH-Generated
         run: |
-          cp -r fsh-generated output
+          ./_build_fgen_index.rb
 
       - name: Publish IG
         uses: JamesIves/github-pages-deploy-action@4.1.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,10 @@ jobs:
           chmod +x ./_genonce.sh
           ./_genonce.sh
 
+      - name: Capture FSH-Generated
+        run: |
+          cp -r fsh-generated output
+
       - name: Publish IG
         uses: JamesIves/github-pages-deploy-action@4.1.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Thumbs.db
 *.sh
 *.bat
 _genonce.sh
+fsh-generated

--- a/_build_fgen_index.rb
+++ b/_build_fgen_index.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+
+# Just a simple script to copy the fsh-generated files over to output and build a very simple index.html file linking to the various files inside the resources directory. 
+
+system("cp -r fsh-generated output")
+File.open("output/fsh-generated/index.html", 'w') { |outf|
+  outf.write("<!DOCTYPE html>  
+<html>
+
+  <body style=\"font-size: 100%;\">
+")
+
+"CodeSystem
+Condition
+Consent
+DocumentReference
+Group
+ImplementationGuide
+List
+Observation
+Organization
+Patient
+Person
+PractitionerRole
+ResearchStudy
+ResearchSubject
+Specimen
+StructureDefinition
+ValueSet".split("\n").each { |rtype|
+    outf.write("\n    <h2>#{rtype}</h2>\n    <ul style='list-style-type: none;'>\n")
+
+    Dir.glob("fsh-generated/resources/#{rtype}-*.json") do |fn|
+      outf.write("      <li><a href='#{fn.sub 'fsh-generated/', ''}'>#{fn.sub 'fsh-generated/resources/', ''}</a></li>\n")
+    end
+    
+    outf.write(    "</ul>\n")
+  }
+
+outf.write("  </body>\n")
+outf.write("</html>\n")
+}
+


### PR DESCRIPTION
# Motivation
As described in Issue #127, there are potentially numerous merge conflicts resulting from the machine generated artifacts inside the fsh-generated directory. These should be removed, however, if it is possible, we'll capture them as part of the IG deployments.  

# Approach
* Delete the directory, fsh-generated, and add it to .gitignore so the files don't creep back in. 
* update GH actions to copy those files to be transferred during deployment. 

