### PR TITLE
🐛 Remove constraints on ids and identifiers

### DIFF
--- a/input/fsh/modules/biospecimen.fsh
+++ b/input/fsh/modules/biospecimen.fsh
@@ -137,7 +137,6 @@ Description: "FHIR Profile for NCPI Sample"
 * collection.extension[biospecimen-spatial] ^short = "Any spatial/location qualifiers"
 * collection.extension contains BiospecimenLaterality named biospecimen-laterality 0..1 /*Biospecimen.Laterality*/
 * collection.extension[biospecimen-laterality] ^short = "Laterality information for the site"
-* container.identifier 1..1 /*Aliquot.AliquotID*/
 * container.identifier ^short = "Unique ID for this aliquot"
 * container.extension contains AliquotAvailability named aliquot-availability 0..1 /*Aliquot.AvailabilityStatus*/
 * container.extension[aliquot-availability] ^short = "Can this Sample be requested for further analysis?"

--- a/input/fsh/modules/biospecimen.fsh
+++ b/input/fsh/modules/biospecimen.fsh
@@ -111,7 +111,6 @@ Description: "FHIR Profile for NCPI Sample"
 * ^status = #draft
 * obeys collection-no-parent
 * obeys parent-no-collection
-* identifier 1..1 /*Sample.SampleID*/
 * identifier ^short = "Unique ID for this sample"
 * subject 1..1 /*Sample.Participant*/
 * subject ^short = "The participant from whom the biospecimen was taken"

--- a/input/fsh/modules/family.fsh
+++ b/input/fsh/modules/family.fsh
@@ -114,9 +114,7 @@ Title: "NCPI Study Family"
 Description: "Study Family"
 * ^version = "0.1.0"
 * ^status = #draft
-* id 1..1 
 * id ^short = "ParticipantID - Unique participant identifier. System identifier used for internal references."
-* identifier 0..* 
 * identifier ^short = "External IDs for this participant. Requires scoping."
 * extension contains FamilyType named family-type 0..1
 * extension[family-type] ^short = "Describes the 'type' of study family, eg, trio."

--- a/input/fsh/modules/files.fsh
+++ b/input/fsh/modules/files.fsh
@@ -136,7 +136,6 @@ Title: "NCPI File"
 Description: "Information about a file related to a research participant"
 * ^version = "0.0.1"
 * ^status = #draft
-* identifier 1..* /*File External ID*/
 * identifier ^short = "A related external file ID"
 * subject 1..1 /*Participant*/
 * subject ^short = "The participant(s) for whom this file contains data (i.e., ParticipantID)"

--- a/input/fsh/modules/participant.fsh
+++ b/input/fsh/modules/participant.fsh
@@ -94,6 +94,7 @@ Logical: CdmPerson
 Id: SharedDataModelPerson
 Title: "Shared Data Model for Research Persons"
 Description: "The **Shared data model for Person**"
+* identifier 1..1 string "Unique Person identifier."
 * participant 1..1 reference "The participant we are describing"
 
 

--- a/input/fsh/modules/participant.fsh
+++ b/input/fsh/modules/participant.fsh
@@ -68,9 +68,7 @@ Title: "NCPI Participant"
 Description: "Research oriented patient"
 * ^version = "0.1.0"
 * ^status = #draft
-* id 1..1 
 * id ^short = "ParticipantID - Unique participant identifier. System identifier used for internal references."
-* identifier 0..* 
 * identifier ^short = "External IDs for this participant. Requires scoping."
 * birthDate ^short = "Date of Birth of the participant. Details of privacy method should be included in DOBMethod"
 * deceased[x] ^short = "Implementers can provide relativeDateTime or actual date or T/F, depending on data available."
@@ -96,7 +94,6 @@ Logical: CdmPerson
 Id: SharedDataModelPerson
 Title: "Shared Data Model for Research Persons"
 Description: "The **Shared data model for Person**"
-* identifier 1..1 string "Unique Person identifier."
 * participant 1..1 reference "The participant we are describing"
 
 
@@ -107,7 +104,6 @@ Title: "NCPI Person"
 Description: "Person"
 * ^version = "0.1.0"
 * ^status = #draft
-* id 1..1 
 * id ^short = "Unique participant identifier"
 * link 1..*
 * link.target only Reference(NcpiParticipant)

--- a/input/fsh/modules/research-study.fsh
+++ b/input/fsh/modules/research-study.fsh
@@ -67,7 +67,6 @@ Description: "The NCPI Research Study FHIR resource represents an individual res
 * ^description = "The NCPI Research Study FHIR resource represents an individual research effort and acts as a grouper or “container” for that effort’s study participants and their related data files."
 * ^version = "0.0.1"
 * ^status = #draft
-* identifier 1..*
 * identifier ^short = "External facing, globally unique identifiers. When providing more than one identifier, researchers should indicate the 'official' identifier by assigning 'official' to that identifier's use property."
 * title ^short = "Study's formal title."
 * description ^short = "Study Description (Recommended)"

--- a/input/fsh/modules/research-study.fsh
+++ b/input/fsh/modules/research-study.fsh
@@ -67,6 +67,7 @@ Description: "The NCPI Research Study FHIR resource represents an individual res
 * ^description = "The NCPI Research Study FHIR resource represents an individual research effort and acts as a grouper or “container” for that effort’s study participants and their related data files."
 * ^version = "0.0.1"
 * ^status = #draft
+* identifier 1..*
 * identifier ^short = "External facing, globally unique identifiers. When providing more than one identifier, researchers should indicate the 'official' identifier by assigning 'official' to that identifier's use property."
 * title ^short = "Study's formal title."
 * description ^short = "Study Description (Recommended)"


### PR DESCRIPTION
# Motivation
This addresses #132 , which captures feedback about constaints added to `id` and `identifier` across

# Approach
I searched across the fsh for `* id ` and `* identifier `, removing those that added constraints we did not want to keep (almost all of them). ResearchStudy still requires an identifier, ie, is `1..*`. 
