### PR TITLE
🍱 Loosen biospecimen requirements

### DIFF
--- a/input/fsh/examples/GREGoR_example.fsh
+++ b/input/fsh/examples/GREGoR_example.fsh
@@ -177,6 +177,17 @@ Description: "Example assertion using data from GREGoR"
   * system = $ucum
 
 //NCPI Biospecimen
+Instance: GSS123456-01-010p /*Collection Event ID can't have underscores*/
+InstanceOf: NCPISample
+Title: "Example biospecimen based on data from GREGoR"
+Usage: #example
+Description: "Example biospecimen based on data from GREGoR"
+* identifier.value = "GSS123456-s1" /*Sample ID*/
+* subject = Reference(GSS123456) /*Participant ID*/
+* type.text = "Blood Draw" /*Sample Type*/
+* collection.method.text = "Blood"
+
+//NCPI Biospecimen
 Instance: GSS123456-01-010 /*Collection Event ID can't have underscores*/
 InstanceOf: NCPISample
 Title: "Example biospecimen based on data from GREGoR"
@@ -185,7 +196,19 @@ Description: "Example biospecimen based on data from GREGoR"
 * identifier.value = "GSS123456-s1" /*Sample ID*/
 * subject = Reference(GSS123456) /*Participant ID*/
 * type.text = "DNA" /*Sample Type*/
+* parent = Reference(GSS123456-01-010p)
+
+//NCPI Biospecimen
+Instance: GSS123456-01-010x /*Collection Event ID can't have underscores*/
+InstanceOf: NCPISample
+Title: "Example biospecimen based on data from GREGoR, intentionally breaking the no parent and collection together rule. This should generate a warning."
+Usage: #example
+Description: "Example biospecimen based on data from GREGoR that will generate a warning"
+* identifier.value = "GSS123456-s1" /*Sample ID*/
+* subject = Reference(GSS123456) /*Participant ID*/
+* type.text = "DNA" /*Sample Type*/
 * collection.method.text = "DNA"
+* parent = Reference(GSS123456-01-010p)
 
 // NCPI File
 Instance: GSS123456-01-010-SG-2

--- a/input/fsh/modules/biospecimen.fsh
+++ b/input/fsh/modules/biospecimen.fsh
@@ -96,8 +96,6 @@ Title: "NCPI Sample"
 Description: "FHIR Profile for NCPI Sample"
 * ^version = "0.1.0"
 * ^status = #draft
-* obeys collection-no-parent
-* obeys parent-no-collection
 * identifier 1..1 /*Sample.SampleID*/
 * identifier ^short = "Unique ID for this sample"
 * subject 1..1 /*Sample.Participant*/

--- a/input/fsh/modules/biospecimen.fsh
+++ b/input/fsh/modules/biospecimen.fsh
@@ -91,7 +91,7 @@ Description: "Concentration of the Aliquot"
 /* Invariant to expect only collection or parent information */
 Invariant:   collection-xor-parent
 Description: "If there is a parent sample, there should be no collection information. If there is collection information present, there should be no parent sample."
-Expression:  "parent.exists() implies collection.empty() and collection.exists() implies parent.empty()"
+Expression: "parent.exists().not() or collection.exists().not()" 
 Severity:    #warning
 
 /*NCPI Sample Profile*/

--- a/input/fsh/modules/biospecimen.fsh
+++ b/input/fsh/modules/biospecimen.fsh
@@ -88,19 +88,6 @@ Description: "Concentration of the Aliquot"
 * value[x] only Quantity
 * valueQuantity ^short = "Specify the concentration of the aliquot"
 
-
-/* Invariant to require collection for parent samples*/
-Invariant:   collection-no-parent
-Description: "If there is no parent sample, collection information must be present. If there is collection information present, there should be no parent sample."
-Expression:  "parent.empty() implies collection.exists() and collection.exists() implies parent.empty()"
-Severity:    #error
-
-/* Invariant to require collection for parent samples*/
-Invariant:   parent-no-collection
-Description: "If there is no collection information, a parent sample must be present. If there is a parent sample present, there should be no collection information."
-Expression:  "collection.empty() implies parent.exists() and parent.exists() implies collection.empty()"
-Severity:    #error
-
 /*NCPI Sample Profile*/
 Profile: NCPISample
 Parent: Specimen
@@ -130,7 +117,6 @@ Description: "FHIR Profile for NCPI Sample"
 * collection.collectedDateTime ^short = "The age at which this biospecimen was collected. Could be expressed with a term, an age, or an age range. (for ages use http://hl7.org/fhir/StructureDefinition/cqf-relativeDateTime)"
 * collection.quantity 0..1 /*Sample.Quantity*/
 * collection.quantity ^short = "The total quantity of the specimen"
-* collection.method 1..1 /*Biospecimen.StorageMethod*/
 * collection.method ^short = "The approach used to collect the biospecimen (unknown if not provided)"
 * collection.bodySite 0..1 /*Biospecimen.Site*/
 * collection.bodySite ^short = "The location of the specimen collection"

--- a/input/fsh/modules/biospecimen.fsh
+++ b/input/fsh/modules/biospecimen.fsh
@@ -88,18 +88,11 @@ Description: "Concentration of the Aliquot"
 * value[x] only Quantity
 * valueQuantity ^short = "Specify the concentration of the aliquot"
 
-
-/* Invariant to require collection for parent samples*/
-Invariant:   collection-no-parent
-Description: "If there is no parent sample, collection information must be present. If there is collection information present, there should be no parent sample."
-Expression:  "parent.empty() implies collection.exists() and collection.exists() implies parent.empty()"
-Severity:    #error
-
-/* Invariant to require collection for parent samples*/
-Invariant:   parent-no-collection
-Description: "If there is no collection information, a parent sample must be present. If there is a parent sample present, there should be no collection information."
-Expression:  "collection.empty() implies parent.exists() and parent.exists() implies collection.empty()"
-Severity:    #error
+/* Invariant to expect only collection or parent information */
+Invariant:   collection-xor-parent
+Description: "If there is a parent sample, there should be no collection information. If there is collection information present, there should be no parent sample."
+Expression:  "parent.exists() implies collection.empty() and collection.exists() implies parent.empty()"
+Severity:    #warning
 
 /*NCPI Sample Profile*/
 Profile: NCPISample
@@ -109,8 +102,7 @@ Title: "NCPI Sample"
 Description: "FHIR Profile for NCPI Sample"
 * ^version = "0.1.0"
 * ^status = #draft
-* obeys collection-no-parent
-* obeys parent-no-collection
+* obeys collection-xor-parent
 * identifier ^short = "Unique ID for this sample"
 * subject 1..1 /*Sample.Participant*/
 * subject ^short = "The participant from whom the biospecimen was taken"
@@ -129,7 +121,6 @@ Description: "FHIR Profile for NCPI Sample"
 * collection.collectedDateTime ^short = "The age at which this biospecimen was collected. Could be expressed with a term, an age, or an age range. (for ages use http://hl7.org/fhir/StructureDefinition/cqf-relativeDateTime)"
 * collection.quantity 0..1 /*Sample.Quantity*/
 * collection.quantity ^short = "The total quantity of the specimen"
-* collection.method 1..1 /*Biospecimen.StorageMethod*/
 * collection.method ^short = "The approach used to collect the biospecimen (unknown if not provided)"
 * collection.bodySite 0..1 /*Biospecimen.Site*/
 * collection.bodySite ^short = "The location of the specimen collection"


### PR DESCRIPTION
# Motivation
This addresses #133 by loosening the requirements for NCPI Sample on collection and parent information.

# Approach
* Remove invariants that made `parent` and `collection` information mutually exclusive.
* Removed requirement for `collection.method`
