### PR TITLE
Fix Errors Caused By Linking to the Sushi Artifacts In Menu

### DIFF
--- a/_build_fgen_index.rb
+++ b/_build_fgen_index.rb
@@ -10,17 +10,17 @@ File.open("output/fshgenidx.html", 'w') { |outf|
 
   <head>
     <title>FSH Generated Artificts</title>
-    <link rel="stylesheet" type="text/css" href="../fhir.css">
+    <link rel="stylesheet" type="text/css" href="fhir.css">
 
     <!-- Bootstrap core CSS -->
-    <link href="../assets/css/bootstrap-fhir.css" rel="stylesheet"/>
+    <link href="assets/css/bootstrap-fhir.css" rel="stylesheet"/>
 
     <!-- Project extras -->
-    <link href="../assets/css/project.css" rel="stylesheet"/>
-    <link href="../assets/css/pygments-manni.css" rel="stylesheet"/>
-    <link href="../assets/css/jquery-ui.css" rel="stylesheet"/>
-  	<link href="../assets/css/prism.css" rel="stylesheet" />
-  	<link href="../assets/css/cqf.css" rel="stylesheet" />
+    <link href="assets/css/project.css" rel="stylesheet"/>
+    <link href="assets/css/pygments-manni.css" rel="stylesheet"/>
+    <link href="assets/css/jquery-ui.css" rel="stylesheet"/>
+  	<link href="assets/css/prism.css" rel="stylesheet" />
+  	<link href="assets/css/cqf.css" rel="stylesheet" />
     <!-- Placeholder for child template CSS declarations -->
 
     <script type="text/javascript" src="fhir-table-scripts.js"> </script>
@@ -32,11 +32,11 @@ File.open("output/fshgenidx.html", 'w') { |outf|
     <![endif]-->
 
     <!-- Favicons -->
-    <link rel="fhir-logo" sizes="144x144" href="../assets/ico/icon-fhir-144.png"/>
-    <link rel="fhir-logo" sizes="114x114" href="../assets/ico/icon-fhir-114.png"/>
-    <link rel="fhir-logo" sizes="72x72" href="../assets/ico/icon-fhir-72.png"/>
-    <link rel="fhir-logo" href="../assets/ico/icon-fhir-57.png"/>
-    <link rel="shortcut icon" href="../assets/ico/favicon.png"/>
+    <link rel="fhir-logo" sizes="144x144" href="assets/ico/icon-fhir-144.png"/>
+    <link rel="fhir-logo" sizes="114x114" href="assets/ico/icon-fhir-114.png"/>
+    <link rel="fhir-logo" sizes="72x72" href="assets/ico/icon-fhir-72.png"/>
+    <link rel="fhir-logo" href="assets/ico/icon-fhir-57.png"/>
+    <link rel="shortcut icon" href="assets/ico/favicon.png"/>
   </head>
   <body style="font-size: 100%;">
 
@@ -44,7 +44,7 @@ File.open("output/fshgenidx.html", 'w') { |outf|
     <div id="segment-breadcrumb" class="segment">  <!-- segment-breadcrumb -->
       <div class="container">  <!-- container -->
         <ul class="breadcrumb">
-          <li><a href='../index.html'><b>Home</b></a></li>
+          <li><a href='index.html'><b>Home</b></a></li>
 
         </ul>
       </div>  <!-- /container -->

--- a/_build_fgen_index.rb
+++ b/_build_fgen_index.rb
@@ -3,7 +3,7 @@
 # Just a simple script to copy the fsh-generated files over to output and build a very simple index.html file linking to the various files inside the resources directory. 
 
 system("cp -r fsh-generated output")
-File.open("output/fsh-generated/index.html", 'w') { |outf|
+File.open("output/fshgenidx.html", 'w') { |outf|
   outf.write(%Q|<!DOCTYPE html>  
 <html>
 

--- a/_build_fgen_index.rb
+++ b/_build_fgen_index.rb
@@ -87,7 +87,7 @@ ValueSet".split("\n").each { |rtype|
     outf.write("\n    <h2>#{rtype}</h2>\n    <ul style='list-style-type: none;'>\n")
 
     Dir.glob("fsh-generated/resources/#{rtype}-*.json") do |fn|
-      outf.write("      <li><a href='#{fn.sub 'fsh-generated/', ''}'>#{fn.sub 'fsh-generated/resources/', ''}</a></li>\n")
+      outf.write("      <li><a href='#{fn}'>#{fn.sub 'fsh-generated/resources/', ''}</a></li>\n")
     end
     
     outf.write(    "</ul>\n")

--- a/input/pagecontent/fshgenidx.md
+++ b/input/pagecontent/fshgenidx.md
@@ -1,0 +1,1 @@
+This is a placeholder for the FSH Generated Index artifact that lists each of the resources produced during the FHIR Shorthand compilation. 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -113,7 +113,7 @@ menu:
     FHIR Versions: fhir_version.html
     FHIR Spec: http://hl7.org/fhir/R4/index.html
     Downloads: downloads.html
-    Sushi Artififacts: fsh-generated/index.html
+    Sushi Artififacts: fshgenidx.html
 
 # ╭───────────────────────────Less Common Implementation Guide Properties──────────────────────────╮
 # │  Uncomment the properties below to configure additional properties on the ImplementationGuide  │


### PR DESCRIPTION
# Motivation
In a recent update, we added a script that an index page to link out to each of the sushi generated artifacts and added it to the IG Artifact's menu. The presence of this link caused an error for every single IG page due to the fact that the file didn't exist until after publisher had finished it's checks. This resulted in 1030 errors in the QA report. 

# Approach
To avoid the errors, there is now a MD file that creates a stub for the page. This allows the publisher validator script to pass even though the true contents of the file won't be created until after the validation is completed. As a result, the QA report should show no build errors (instead of the 1030 we were seeing previously). 
