### PR TITLE
♻️ Reference external valuesets for assertions

### DIFF
--- a/input/fsh/modules/participant_assertion.fsh
+++ b/input/fsh/modules/participant_assertion.fsh
@@ -52,7 +52,7 @@ Title: "Assertion of Phenotypic Feature Codes"
 Description: "Assertion of Phenotypic Feature Codes"
 * ^experimental = false
 * include codes from valueset http://terminology.hl7.org/ValueSet/v3-NullFlavor
-* include codes from valueset https://fhir.loinc.org/ValueSet/?url=http://loinc.org/vs/LL3950-4
+* include codes from valueset https://fhir.loinc.org/ValueSet/LL3950-4
 
 ValueSet: PhenotypicFeatureCodeVS
 Id: phenotypic-feature-code-vs

--- a/input/fsh/modules/participant_assertion.fsh
+++ b/input/fsh/modules/participant_assertion.fsh
@@ -51,8 +51,9 @@ Id: phenotypic-feature-assertion-vs
 Title: "Assertion of Phenotypic Feature Codes"
 Description: "Assertion of Phenotypic Feature Codes"
 * ^experimental = false
+* include http://loinc.org/#LA9633-4 "Present"
+* include http://loinc.org/#LA9634-2 "Absent"
 * include codes from valueset http://terminology.hl7.org/ValueSet/v3-NullFlavor
-* include codes from valueset https://fhir.loinc.org/ValueSet/LL3950-4
 
 ValueSet: PhenotypicFeatureCodeVS
 Id: phenotypic-feature-code-vs

--- a/input/fsh/modules/participant_assertion.fsh
+++ b/input/fsh/modules/participant_assertion.fsh
@@ -51,8 +51,8 @@ Id: phenotypic-feature-assertion-vs
 Title: "Assertion of Phenotypic Feature Codes"
 Description: "Assertion of Phenotypic Feature Codes"
 * ^experimental = false
-* include http://loinc.org/#LA9633-4 "Present"
-* include http://loinc.org/#LA9634-2 "Absent"
+* include http://loinc.org#LA9633-4 "Present"
+* include http://loinc.org#LA9634-2 "Absent"
 * include codes from valueset http://terminology.hl7.org/ValueSet/v3-NullFlavor
 
 ValueSet: PhenotypicFeatureCodeVS

--- a/input/fsh/modules/participant_assertion.fsh
+++ b/input/fsh/modules/participant_assertion.fsh
@@ -46,23 +46,13 @@ Description: "Type of Condition"
 * ^experimental = false
 * include codes from system condition-type
 
-CodeSystem: PhenotypicFeatureAssertion
-Id: phenotypic-feature-assertion
-Title: "Assertion of Phenotypic Feature Codes"
-Description: "Code System for assertion of phenotypic feature presence"
-* ^url = $phenotypic-feature-assertion
-* ^experimental = false
-* ^caseSensitive = true
-* #Present "Present"
-* #Absent "Absent"
-* #Unknown "Unknown"
-
 ValueSet: PhenotypicFeatureAssertionVS
 Id: phenotypic-feature-assertion-vs
 Title: "Assertion of Phenotypic Feature Codes"
 Description: "Assertion of Phenotypic Feature Codes"
 * ^experimental = false
-* include codes from system phenotypic-feature-assertion
+* include codes from valueset http://terminology.hl7.org/ValueSet/v3-NullFlavor
+* include codes from valueset https://fhir.loinc.org/ValueSet/?url=http://loinc.org/vs/LL3950-4
 
 ValueSet: PhenotypicFeatureCodeVS
 Id: phenotypic-feature-code-vs


### PR DESCRIPTION
Replaces the internal Phenotypic Feature Assertion CodeSystem with external ValueSet references to LOINC and HL7.

# Motivation
Intended to address #137 

# Approach
Replaces our custom Present / Absent concepts with: https://loinc.org/LL3950-4
Adds the HL7 FHIR NullFlavor ValueSet: https://terminology.hl7.org/1.0.0/ValueSet-v3-NullFlavor.html